### PR TITLE
Fix some bugs and improve compatibility

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -5,7 +5,7 @@ import os
 
 directory = 'figures'
 logfile = 'test.log'
-enc = 'Latin-1'
+enc = 'utf-8' # For Overleaf, try 'Latin-1' if issues encountered...
 
 for filename in os.listdir(directory):
     if filename in open(logfile, encoding=enc).read():

--- a/clean.py
+++ b/clean.py
@@ -4,14 +4,15 @@
 import os
 
 directory = 'figures'
-logfile = 'rus.log'
+logfile = 'test.log'
+enc = 'Latin-1'
 
 for filename in os.listdir(directory):
-    if filename in open(logfile).read():
-        print filename + " in use."
+    if filename in open(logfile, encoding=enc).read():
+        print(filename + ' in use.')
     else:
-        if os.path.isfile(filename):
-            print filename + " not in use - deleting."
-            os.remove(directory + "/" + filename)
+        if os.path.isfile(os.path.join(directory, filename)):
+            print(filename + ' not in use - deleting.')
+            os.remove(os.path.join(directory, filename))
         else:
-            print filename + " is a directory."
+            print(filename + ' is a directory.')


### PR DESCRIPTION
Thanks for making this useful script!

- I made quotation marks consistent for style's sake
- There was also a bug, the script checked for `filename` not `os.path.join(directory, filename))`
- `os.path.join` is preferable over `+ '/'` for cross-platform compatibility
- LaTeX log files generated by Overleaf are in a strange encoding; thus I added an encoding parameter -- probably you don't usually need to use this, but it addresses the popular edge case of Overleaf at least